### PR TITLE
fix: store page 비 로그인, 삭제 페이지 예외 처리

### DIFF
--- a/src/main/java/com/kosa/mini/controller/store/StoreContentController.java
+++ b/src/main/java/com/kosa/mini/controller/store/StoreContentController.java
@@ -3,6 +3,7 @@ package com.kosa.mini.controller.store;
 import com.kosa.mini.domain.store.*;
 import com.kosa.mini.service.store.StoreContentService;
 import com.kosa.mini.service.store.StoreService;
+import jakarta.servlet.http.HttpSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -27,7 +28,14 @@ public class StoreContentController {
     // 가게 내용 + 댓글 정보 불러오기
     @GetMapping("/{num}")
     public String getStoreInfo(@PathVariable int num,
-                               Model model) {
+                               Model model,
+                               HttpSession session) {
+        // 로그인 상태인지 확인
+        Object loggedInUser = session.getAttribute("loggedInUser");
+        if (loggedInUser == null) {
+            return "redirect:/login";
+        }
+        
         StoreContentDTO store = service.storeInfo(num);
         List<Menu> menu = service.getStoreMenuAll(num);
         List<ReviewReplyDTO> review = service.getStoreReplyAll(num);


### PR DESCRIPTION
비 로그인 상태에서 /store/{num} 접속 시, 접속 불가

삭제된 store/{num} 입력 시, 접근 거부 페이지로 이동
접근 거부 페이지 header, footer 적용
![image](https://github.com/user-attachments/assets/7b789a00-545c-4625-a383-f3f78db3a68d)
