### PR TITLE
fix: 리뷰 수정 시 메세지 안뜨는 오류 수정

### DIFF
--- a/frontend/src/views/StoreContent.vue
+++ b/frontend/src/views/StoreContent.vue
@@ -1023,7 +1023,9 @@ export default {
     };
 
     // Update Reply
-    const updateReply = async () => {
+    const updateReply = async (event) => {
+      // page reload 방지
+      event.preventDefault();
       if (!editReplyText.value) {
         alert("답글을 작성해주세요.");
         return;

--- a/frontend/src/views/StoreContent.vue
+++ b/frontend/src/views/StoreContent.vue
@@ -977,7 +977,10 @@ export default {
     };
 
     // Update Review
-    const updateReview = async () => {
+    const updateReview = async (event) => {
+      // page reload 방지
+      event.preventDefault();
+
       if (!editReviewText.value) {
         alert("후기를 작성해주세요.");
         return;
@@ -990,11 +993,7 @@ export default {
             reviewId: currentReview.value.reviewId,
             rating: newReview.value.rating, // Maintain existing rating
             reviewText: editReviewText.value,
-          }
-        );
-        console.log(
-          `/reviews/${store.value.storeId}/${currentReview.value.reviewId}`
-        );
+          });
         alert("후기가 성공적으로 수정되었습니다.");
         closeEditModal();
         await fetchReviews();


### PR DESCRIPTION
- 리뷰 작성, 수정, 삭제 시 메세지 확인
![화면 캡처 2024-11-21 153632](https://github.com/user-attachments/assets/67033963-2232-4717-9322-39dbf4a50d64)
![화면 캡처 2024-11-21 153646](https://github.com/user-attachments/assets/f38f3cba-c345-4f13-8559-e4f87cd965ff)
![화면 캡처 2024-11-21 153656](https://github.com/user-attachments/assets/f5a7c718-2f46-4cf1-8a24-bed552184c19)

- 리뷰 수정 메세지가 나타나지 않았던 이유
patch 요청 후 페이지가 새로 고침되는 되면서 alert 메세지가 표시되기 전에
페이지가 갱신되어 메세지가 나타나지 않은 것으로 추정

- 해결 방법
 const updateReply = async (event) => {
      event.preventDefault();

코드를 추가하여 새로고침 방지
